### PR TITLE
Get capnp_schema table via require, not via global environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CAT = /bin/cat
 SCHEMA = /usr/local/include/capnp/schema.capnp
 TARGET = $(basename $(notdir $(input)))
 
-define MSG =
+define MSG
 The purpose of this Makefile is to generate new schemas for the capnp dissector.
 
 Usage:
@@ -15,10 +15,8 @@ by the capnp protocol dissector.
 endef
 export MSG
 
-define HEAD =
-if not capnp_schema then
-   capnp_schema = {}
-end
+define HEAD
+local capnp_schema = require("capnp_schema")
 
 -- fake atoms
 local void = "void"

--- a/plugins/capnp.lua
+++ b/plugins/capnp.lua
@@ -14,6 +14,8 @@
 --   limitations under the License.
 --
 
+local capnp_schema = require("capnp_schema")
+
 local proto = Proto("capnp", "Cap'n Proto RPC Protocol")
 local tcp_port, udp_port
 local dir_marker = {}

--- a/plugins/capnp_schema.lua
+++ b/plugins/capnp_schema.lua
@@ -1,6 +1,4 @@
-if not capnp_schema then
-   capnp_schema = {}
-end
+local capnp_schema = {}
 
 local function find(s, key, val)
    for _, n in ipairs(s) do
@@ -28,3 +26,5 @@ setmetatable(
         return node
    end
 })
+
+return capnp_schema

--- a/plugins/rpc_capnp.lua
+++ b/plugins/rpc_capnp.lua
@@ -1,6 +1,4 @@
-if not capnp_schema then
-   capnp_schema = {}
-end
+local capnp_schema = require("capnp_schema")
 
 -- fake atoms
 local void = "void"


### PR DESCRIPTION
This fixes #1 
