### PR TITLE
Handle TCP segmentation

### DIFF
--- a/plugins/capnp.lua
+++ b/plugins/capnp.lua
@@ -94,7 +94,7 @@ end
 
 function dissect.message(buf, pkt, root)
    local count = buf(0,4):le_uint() + 1
-   local seg_table_size = 4 * (count + count % 2)
+   local seg_table_size = 8 * (1 + count // 2)
    local data = buf(seg_table_size):tvb()
    local segs = {}
    local tree = root:add(proto, buf(0, seg_table_size))


### PR DESCRIPTION
With these changes, the plugin can handle cases where a message spans over several TCP segments. Example screenshot:

![image](https://github.com/user-attachments/assets/af0ce1bc-c940-4a0b-9a99-828460e6f4e0)

This will most probably fix the issue #4 related to out-of-bounds indexing.

There was two problems with the message dissector:

1. The segment table calculation of the Cap'n Proto's message. The table is tail padded to meet the 64-bit alignment criteria. See [this](https://capnproto.org/encoding.html#serialization-over-a-stream).

2. The message dissector expects a complete message in the buffer. In this PR, the total message size is calculated and if there is not enough bytes available, the Wireshark is asked to desegment more bytes. See [this blog post](https://www.niklas-semmler.net/programming/wireshark/lua/2017/02/07/writing_a_wireshark_dissector.html) as reference.
